### PR TITLE
add const char cast to avoid string-plus-int warning

### DIFF
--- a/include/alglog.h
+++ b/include/alglog.h
@@ -121,7 +121,7 @@
         return 0;
     }
 
-    #define __ALGLOG_FNAME__ (__FILE__ + _alglog_fname_offset(__FILE__))
+    #define __ALGLOG_FNAME__ ((const char*)__FILE__ + _alglog_fname_offset(__FILE__))
 #endif
 
 // -------------------------------------------------------


### PR DESCRIPTION
linuxの一部環境で `__FILE__` と`size_t`の+演算に対して警告が出ていたので対応しました