### PR TITLE
Fix build error when ALGLOG_GETTID_OFF is defined

### DIFF
--- a/include/alglog.h
+++ b/include/alglog.h
@@ -90,7 +90,7 @@
 // スレッドIDを取得する。もしくは機能を利用しない。
 #ifdef ALGLOG_GETTID_OFF
     inline std::thread::id get_thread_id(){
-        return std::thread::id(0);
+        return std::thread::id();
     }
 #else
     inline std::thread::id get_thread_id(){


### PR DESCRIPTION
This PR fixes the build error that occurs when ALGLOG_GETTID_OFF is defined by changing std::thread::id(0) to std::thread::id() to avoid using a private constructor.

Link to Devin run: https://app.devin.ai/sessions/0b1138655e6a4d649a89d672663f8b2e

※このPRは @kuguma の指示によりdevinが作成しました。
